### PR TITLE
Added the convert to lowercase button

### DIFF
--- a/src/components/TextForm.js
+++ b/src/components/TextForm.js
@@ -7,7 +7,7 @@ export default function TextForm(props) {
 		props.showAlert("Converted to uppercase!", "success");
 	};
 
-	const handleDownClick = () => {
+	const handleLowCase = () => {
 		let newText = text.toLowerCase();
 		setText(newText);
 		props.showAlert("Converted to lowercase!", "success");
@@ -53,7 +53,7 @@ export default function TextForm(props) {
 				<button
 					disabled={text.length === 0}
 					className="btn btn-primary mx-1 my-1"
-					onClick={handleDownClick}
+					onClick={handleLowCase}
 				>
 					Convert to Lowercase
 				</button>

--- a/src/components/TextForm.js
+++ b/src/components/TextForm.js
@@ -7,6 +7,12 @@ export default function TextForm(props) {
 		props.showAlert("Converted to uppercase!", "success");
 	};
 
+	const handleDownClick = () => {
+		let newText = text.toLowerCase();
+		setText(newText);
+		props.showAlert("Converted to lowercase!", "success");
+	};
+
 	const handleOnChange = (event) => {
 		setText(event.target.value);
 	};
@@ -43,6 +49,13 @@ export default function TextForm(props) {
 					onClick={handleUpClick}
 				>
 					Convert to Uppercase
+				</button>
+				<button
+					disabled={text.length === 0}
+					className="btn btn-primary mx-1 my-1"
+					onClick={handleDownClick}
+				>
+					Convert to Lowercase
 				</button>
 			</div>
 			<div


### PR DESCRIPTION
This closes #3 by adding the convert to lowercase button. 

The hardest part of this was getting the code to run. I had to set `$env:NODE_OPTIONS="--openssl-legacy-provider"`
Which I got from [this](https://stackoverflow.com/questions/69394632/webpack-build-failing-with-err-ossl-evp-unsupported) stack overflow article: 